### PR TITLE
Hot Fix - Minor Improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ jobs:
           data-path: '/examples/model_card_output/data/loan_approval_example.proto'
 ```
 
-The `data-path` input is required. It must be specify for the action to read the dataset from a specific path in order to generate test result.
+The `data-path` input is required - the action will read the model card from the given path and use it to generate the test results.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "verifyml-reports",
-  "version": "1.0.10",
-  "private": true,
+  "version": "1.0.11",
+  "private": false,
   "description": "Automated documentation of model and alerts from performance / fairness checks.",
   "main": "dist/index.js",
   "engines": {
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cylynx/verifyml-gh-actions.git"
+    "url": "git+https://github.com/cylynx/verifyml-report.git"
   },
   "keywords": [
     "VerifyML"
@@ -24,9 +24,9 @@
   "author": "Cylynx Pte Ltd",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cylynx/verifyml-gh-actions/issues"
+    "url": "https://github.com/cylynx/verifyml-report/issues"
   },
-  "homepage": "https://github.com/cylynx/verifyml-gh-actions#README",
+  "homepage": "https://github.com/cylynx/verifyml-report#README",
   "devDependencies": {
     "@commitlint/cli": "^15.0.0",
     "@commitlint/config-conventional": "^15.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "noUnusedParameters": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "noEmit": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "public"]


### PR DESCRIPTION
## Changes 

- Improve docs according to suggestion.
- Typescript compiler is used to perform type-checking only, disable emitting file during typescript compilation to prevent the file emitted conflicts with `@vercel/ncc`.
- Update NPM metadata for more accurate information